### PR TITLE
Removed NonParallelizable attribute with individual instance of TestLog per async context

### DIFF
--- a/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionProceedsOnlyAfterAllAfterTestHooksExecute.cs
+++ b/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionProceedsOnlyAfterAllAfterTestHooksExecute.cs
@@ -32,7 +32,6 @@ namespace NUnit.Framework.Tests.HookExtension.ExecutionSequence
         }
 
         [Test]
-        [NonParallelizable]
         public void TestProceedsAfterAllAfterTestHooksExecute()
         {
             var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionProceedsOnlyAfterAllBeforeTestHooksExecute.cs
+++ b/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionProceedsOnlyAfterAllBeforeTestHooksExecute.cs
@@ -20,7 +20,6 @@ public class ExecutionProceedsOnlyAfterAllBeforeTestHooksExecute
     }
 
     [Test]
-    [NonParallelizable]
     public void CheckThatLongRunningBeforeTestHooksCompleteBeforeTest()
     {
         var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionSequenceWithAllPossibleHooks.cs
+++ b/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionSequenceWithAllPossibleHooks.cs
@@ -43,7 +43,6 @@ namespace NUnit.Framework.Tests.HookExtension.ExecutionSequence
         }
 
         [Test]
-        [NonParallelizable]
         public void TestProceedsAfterAllAfterTestHooksExecute()
         {
             var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionSequenceWithTestActionTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/ExecutionSequence/ExecutionSequenceWithTestActionTests.cs
@@ -51,7 +51,6 @@ namespace NUnit.Framework.Tests.HookExtension.ExecutionSequence
         }
 
         [Test]
-        [NonParallelizable]
         public void TestProceedsAfterAllAfterTestHooksExecute()
         {
             var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterOneTimSetUpHooksEvaluateTestOutcomeTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterOneTimSetUpHooksEvaluateTestOutcomeTests.cs
@@ -74,7 +74,6 @@ public class AfterOneTimeSetUpHooksEvaluateTestOutcomeTests
     }
 
     [TestSetupUnderTest]
-    [NonParallelizable]
     [AfterSetUpOutcomeLogger]
     [TestFixtureSource(nameof(GetFixtureConfig))]
     public class TestsUnderTestsWithDifferentOntTimeSetUpOutcome
@@ -147,7 +146,7 @@ public class AfterOneTimeSetUpHooksEvaluateTestOutcomeTests
     }
 
     [Test]
-    [NonParallelizable]
+    
     public void CheckSetUpOutcomes()
     {
         var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterOneTimeTearDownHooksEvaluateTestOutcomeTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterOneTimeTearDownHooksEvaluateTestOutcomeTests.cs
@@ -77,7 +77,6 @@ public class AfterOneTimeOneTimeTearDownHooksEvaluateTestOutcomeTests
     // H-TODO: enrich or write new test for exceptions from hooks
 
     [TestSetupUnderTest]
-    [NonParallelizable]
     [AfterOneTimeTearDownOutcomeLogger]
     [TestFixtureSource(nameof(GetFixtureConfig))]
     public class TestsUnderTestsWithDifferentOneTimeTearDownOutcome
@@ -145,7 +144,7 @@ public class AfterOneTimeOneTimeTearDownHooksEvaluateTestOutcomeTests
     }
 
     [Test]
-    [NonParallelizable]
+    
     public void CheckOneTimeTearDownOutcomes()
     {
         var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterSetUpHooksEvaluateTestOutcomeTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterSetUpHooksEvaluateTestOutcomeTests.cs
@@ -72,7 +72,6 @@ public class AfterSetUpHooksEvaluateTestOutcomeTests
     }
 
     [TestSetupUnderTest]
-    [NonParallelizable]
     [AfterSetUpOutcomeLogger]
     [TestFixtureSource(nameof(GetFixtureConfig))]
     public class TestsUnderTestsWithDifferentSetUpOutcome
@@ -146,7 +145,7 @@ public class AfterSetUpHooksEvaluateTestOutcomeTests
     }
 
     [Test]
-    [NonParallelizable]
+    
     public void CheckSetUpOutcomes()
     {
         var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterTearDownHooksEvaluateTestOutcomeTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterTearDownHooksEvaluateTestOutcomeTests.cs
@@ -70,7 +70,6 @@ public class AfterTearDownHooksEvaluateTestOutcomeTests
     // H-TODO: enrich the test to also failing tests and setups
 
     [TestSetupUnderTest]
-    [NonParallelizable]
     [AfterTearDownOutcomeLogger]
     [TestFixtureSource(nameof(GetFixtureConfig))]
     public class TestsUnderTestsWithDifferentTearDownOutcome
@@ -137,7 +136,7 @@ public class AfterTearDownHooksEvaluateTestOutcomeTests
     }
 
     [Test]
-    [NonParallelizable]
+    
     public void CheckTearDownOutcomes()
     {
         var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterTestHooksEvaluateTestOutcome.cs
+++ b/src/NUnitFramework/tests/HookExtension/TestOutcomeTests/AfterTestHooksEvaluateTestOutcome.cs
@@ -47,7 +47,6 @@ public class AfterTestOutcomeLogger : NUnitAttribute, IApplyToContext
 public class AfterTestHooksEvaluateTestOutcomeTests
 {
     [TestSetupUnderTest]
-    [NonParallelizable]
     [AfterTestOutcomeLogger]
     public class TestsUnderTestsWithMixedOutcome
     {
@@ -89,7 +88,7 @@ public class AfterTestHooksEvaluateTestOutcomeTests
     }
 
     [Test]
-    [NonParallelizable]
+    
     public void CheckThatAfterTestHooksEvaluateTestOutcome()
     {
         var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/ThreadingTests/AsynchronousBeforeTestHookInvocationTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/ThreadingTests/AsynchronousBeforeTestHookInvocationTests.cs
@@ -79,7 +79,6 @@ namespace NUnit.Framework.Tests.HookExtension.ThreadingTests
         }
 
         [Test]
-        [NonParallelizable]
         [Explicit("Thread IDs is not a good way to test. Are we testing dot net framework here??")]
         public void AsynchronousHookInvocation_HookExecutesInSeparateThreads()
         {

--- a/src/NUnitFramework/tests/HookExtension/ThreadingTests/SynchronousHookInvocationTests.cs
+++ b/src/NUnitFramework/tests/HookExtension/ThreadingTests/SynchronousHookInvocationTests.cs
@@ -63,7 +63,6 @@ namespace NUnit.Framework.Tests.HookExtension.ThreadingTests
         }
 
         [Test]
-        [NonParallelizable]
         public void SynchronousHookInvocation_HookExecutesInSameThreadAsTest()
         {
             var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/HookExtension/TwoTests_WithAndWithoutLoggerHook_BeforeAfterTestOnlyOneTestLogged.cs
+++ b/src/NUnitFramework/tests/HookExtension/TwoTests_WithAndWithoutLoggerHook_BeforeAfterTestOnlyOneTestLogged.cs
@@ -23,7 +23,6 @@ namespace NUnit.Framework.Tests.HookExtension
         }
 
         [Test]
-        [NonParallelizable]
         public void CheckLoggingTest()
         {
             var testResult = TestsUnderTest.Execute();

--- a/src/NUnitFramework/tests/TestUtilities/TestsUnderTest/TestLog.cs
+++ b/src/NUnitFramework/tests/TestUtilities/TestsUnderTest/TestLog.cs
@@ -2,12 +2,26 @@
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace NUnit.Framework.Tests.TestUtilities.TestsUnderTest;
 
 public static class TestLog
 {
-    public static List<string> Logs { get; } = new List<string>();
+    private static readonly AsyncLocal<List<string>> _logs = new AsyncLocal<List<string>>();
+
+    // Each aync context gets its own instance of TestLog
+    public static List<string> Logs
+    {
+        get
+        {
+            if (_logs.Value == null)
+            {
+                _logs.Value = new List<string>();
+            }
+            return _logs.Value;
+        }
+    }
 
     public static void Log(string infoToLog)
     {


### PR DESCRIPTION
Removed NonParallelizable attribute with individual instance of TestLog per async context